### PR TITLE
修复32位系统下越界中断问题

### DIFF
--- a/cls/adapter.cpp
+++ b/cls/adapter.cpp
@@ -262,7 +262,7 @@ void LOGAdapter::Send(const string& httpMethod, const string& host, const int32_
         if (httpMethod == HTTP_POST)
         {
             curl_easy_setopt(curl, CURLOPT_POST, 1);
-            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, body.size());
+            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(body.size()));
             curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
         }
         else if (httpMethod == HTTP_DELETE)
@@ -272,7 +272,7 @@ void LOGAdapter::Send(const string& httpMethod, const string& host, const int32_
         else if (httpMethod == HTTP_PUT)
         {
             curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, HTTP_PUT);
-            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, body.size());
+            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(body.size()));
             curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
         }
 


### PR DESCRIPTION
原因：在 32 位系统上，size_t 是 32 位，而 CURLOPT_POSTFIELDSIZE_LARGE 期望 64 位的 curl_off_t。

改动点：更改为static_cast<curl_off_t>(body.size())，以确保类型匹配正确。

影响范围：在32位系统上，解决了越界问题，其他地方无改动；对于64位系统没有改动。