### PR TITLE
Feature windows

### DIFF
--- a/cls/adapter.cpp
+++ b/cls/adapter.cpp
@@ -143,7 +143,7 @@ time_t CodecTool::DecodeDateString(const std::string dateString, const std::stri
             std::string("Failed to convert tm to time_t for date string:") + dateString + ", format:" + dateFormat);
     }
 
-    // ï¿½ï¿½È¡ï¿½ï¿½Ç°Ê±ï¿½ï¿½Æ«ï¿½Æ£ï¿½ï¿½ï¿½ï¿½Ó£ï¿½
+    // »ñÈ¡µ±Ç°Ê±ÇøÆ«ÒÆ£¨·ÖÖÓ£©
     TIME_ZONE_INFORMATION tzInfo;
     DWORD tzResult = GetTimeZoneInformation(&tzInfo);
     if (tzResult == TIME_ZONE_ID_INVALID) {
@@ -290,7 +290,7 @@ void LOGAdapter::Send(const string& httpMethod, const string& host, const int32_
         if (httpMethod == HTTP_POST)
         {
             curl_easy_setopt(curl, CURLOPT_POST, 1);
-            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(body.size()));
+            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, body.size());
             curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
         }
         else if (httpMethod == HTTP_DELETE)
@@ -300,7 +300,7 @@ void LOGAdapter::Send(const string& httpMethod, const string& host, const int32_
         else if (httpMethod == HTTP_PUT)
         {
             curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, HTTP_PUT);
-            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(body.size()));
+            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, body.size());
             curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
         }
 

--- a/cls/adapter.cpp
+++ b/cls/adapter.cpp
@@ -143,7 +143,7 @@ time_t CodecTool::DecodeDateString(const std::string dateString, const std::stri
             std::string("Failed to convert tm to time_t for date string:") + dateString + ", format:" + dateFormat);
     }
 
-    // 获取当前时区偏移（分钟）
+    // 鑾峰彇褰撳墠鏃跺尯鍋忕Щ锛堝垎閽燂級
     TIME_ZONE_INFORMATION tzInfo;
     DWORD tzResult = GetTimeZoneInformation(&tzInfo);
     if (tzResult == TIME_ZONE_ID_INVALID) {
@@ -290,7 +290,7 @@ void LOGAdapter::Send(const string& httpMethod, const string& host, const int32_
         if (httpMethod == HTTP_POST)
         {
             curl_easy_setopt(curl, CURLOPT_POST, 1);
-            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, body.size());
+            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(body.size()));
             curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
         }
         else if (httpMethod == HTTP_DELETE)
@@ -300,7 +300,7 @@ void LOGAdapter::Send(const string& httpMethod, const string& host, const int32_
         else if (httpMethod == HTTP_PUT)
         {
             curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, HTTP_PUT);
-            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, body.size());
+            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(body.size()));
             curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
         }
 

--- a/cls/adapter.cpp
+++ b/cls/adapter.cpp
@@ -143,7 +143,7 @@ time_t CodecTool::DecodeDateString(const std::string dateString, const std::stri
             std::string("Failed to convert tm to time_t for date string:") + dateString + ", format:" + dateFormat);
     }
 
-    // »ñÈ¡µ±Ç°Ê±ÇøÆ«ÒÆ£¨·ÖÖÓ£©
+    // ï¿½ï¿½È¡ï¿½ï¿½Ç°Ê±ï¿½ï¿½Æ«ï¿½Æ£ï¿½ï¿½ï¿½ï¿½Ó£ï¿½
     TIME_ZONE_INFORMATION tzInfo;
     DWORD tzResult = GetTimeZoneInformation(&tzInfo);
     if (tzResult == TIME_ZONE_ID_INVALID) {
@@ -290,7 +290,7 @@ void LOGAdapter::Send(const string& httpMethod, const string& host, const int32_
         if (httpMethod == HTTP_POST)
         {
             curl_easy_setopt(curl, CURLOPT_POST, 1);
-            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, body.size());
+            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(body.size()));
             curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
         }
         else if (httpMethod == HTTP_DELETE)
@@ -300,7 +300,7 @@ void LOGAdapter::Send(const string& httpMethod, const string& host, const int32_
         else if (httpMethod == HTTP_PUT)
         {
             curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, HTTP_PUT);
-            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, body.size());
+            curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(body.size()));
             curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
         }
 


### PR DESCRIPTION
原因：在 32 位系统上，size_t 是 32 位，而 CURLOPT_POSTFIELDSIZE_LARGE 期望 64 位的 curl_off_t。

改动点：更改为static_cast<curl_off_t>(body.size())，以确保类型匹配正确。

影响范围：在32位系统上，解决了越界问题，其他地方无改动；对于64位系统没有改动。